### PR TITLE
Reenable categories header dropdown

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -84,6 +84,8 @@
       </div>
     </footer>
 
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
     <script
       src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js" />
 


### PR DESCRIPTION
Addresses [#2875](https://github.com/morty-tech/morty/issues/2875).

I'm not sure if there is a staging environment for the blog, but see below for screenshots.

## The problem

We weren't importing JQuery. The dropdown wouldn't open because it
uses Bootstrap, which needed JQuery.

## Screenshots
![Screen Shot 2021-09-01 at 10 31 03 AM](https://user-images.githubusercontent.com/19334278/131690068-6d1c069a-4000-44e7-bbd5-8302cb64467b.png)
![Screen Shot 2021-09-01 at 10 31 11 AM](https://user-images.githubusercontent.com/19334278/131690151-dbf2d201-931a-4631-bf65-149e5261e070.png)
